### PR TITLE
Refine Proxy

### DIFF
--- a/examples/simple-api-test/src/test/kotlin/Steps.kt
+++ b/examples/simple-api-test/src/test/kotlin/Steps.kt
@@ -2,7 +2,7 @@ import com.example.demoapp.App
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.thoughtworks.gauge.AfterSuite
 import com.thoughtworks.gauge.BeforeSuite
-import com.uzabase.playtest2.core.config.Configuration
+import com.uzabase.playtest2.core.config.Configuration.Companion.playtest2
 import com.uzabase.playtest2.core.config.plus
 import com.uzabase.playtest2.http.config.http
 import com.uzabase.playtest2.wiremock.config.wireMock
@@ -13,7 +13,7 @@ class Steps {
 
     @BeforeSuite
     fun beforeSuite() {
-        Configuration.playtest2 {
+        playtest2 {
             http(URI("http://localhost:8080").toURL()) +
                     wireMock("InnerAPI", URI("http://localhost:3000").toURL())
         }

--- a/playtest-core/src/main/kotlin/com/uzabase/playtest2/core/proxy/ProxyFactory.kt
+++ b/playtest-core/src/main/kotlin/com/uzabase/playtest2/core/proxy/ProxyFactory.kt
@@ -1,61 +1,31 @@
 package com.uzabase.playtest2.core.proxy
 
 import com.uzabase.playtest2.core.assertion.Assertable
-import com.uzabase.playtest2.core.assertion.PlaytestException
-import com.uzabase.playtest2.core.assertion.playtestException
-import com.uzabase.playtest2.core.zoom.Zoomable
-import java.lang.reflect.Proxy
 
-data class AssertableProxyFunctions<T>(
-    val asString: (T) -> String = { throw PlaytestException("Cannot convert $it to String") },
-    val asLong: (T) -> Long = { throw PlaytestException("Cannot convert $it to Long") },
-    val asBoolean: (T) -> Boolean = { throw PlaytestException("Cannot convert $it to Boolean") },
-    val asRaw: (T) -> Any = { it as Any }
-)
-
-fun <K> unzoomable(): Zoomable<K> = object : Zoomable<K> {
-    override fun zoom(key: K): Any {
-        throw UnsupportedOperationException("Cannot zoom")
-    }
-
-}
-
-@Suppress("UNCHECKED_CAST")
 class ProxyFactory {
     companion object {
-        inline fun <reified A, K> make(
-            obj: A,
-            fns: AssertableProxyFunctions<A>,
-            zoomable: Zoomable<K> = unzoomable()
-        ): Any =
-            Proxy.newProxyInstance(
-                Assertable::class.java.classLoader,
-                arrayOf(
-                    Assertable::class.java,
-                    Zoomable::class.java
-                )
-            ) { _, method, args ->
-                when (method.name) {
-                    "asString" -> fns.asString(obj)
-                    "asLong" -> fns.asLong(obj)
-                    "asBoolean" -> fns.asBoolean(obj)
-                    "asRaw" -> fns.asRaw(obj)
-                    "zoom" -> zoomable.zoom(args[0] as K)
-                    else -> playtestException("Cannot execute this method")
-                }
+        fun ofString(s: String): Assertable =
+            object : Assertable {
+                override fun asLong(): Long = s.toLong()
+                override fun asString(): String = s
+                override fun asBoolean(): Boolean = s.toBoolean()
+                override fun asRaw(): Any = s
             }
 
-        fun fromStringValue(s: String): Any = make<String, Unit>(s, AssertableProxyFunctions(
-            asString = { s },
-            asBoolean = { s.toBoolean() }
-        ))
+        fun ofLong(l: Long): Assertable =
+            object : Assertable {
+                override fun asLong(): Long = l
+                override fun asString(): String = l.toString()
+                override fun asBoolean(): Boolean = throw UnsupportedOperationException()
+                override fun asRaw(): Any = l
+            }
 
-        fun fromLongValue(l: Long): Any = make<Long, Unit>(l, AssertableProxyFunctions(
-            asLong = { l }
-        ))
-
-        fun fromBooleanValue(b: Boolean) = make<Boolean, Unit>(b, AssertableProxyFunctions(
-            asBoolean = { b }
-        ))
+        fun ofBoolean(b: Boolean): Assertable =
+            object : Assertable {
+                override fun asLong(): Long = throw UnsupportedOperationException()
+                override fun asString(): String = b.toString()
+                override fun asBoolean(): Boolean = b
+                override fun asRaw(): Any = b
+            }
     }
 }

--- a/playtest-core/src/test/kotlin/com/uzabase/playtest2/core/config/ConfigurationTest.kt
+++ b/playtest-core/src/test/kotlin/com/uzabase/playtest2/core/config/ConfigurationTest.kt
@@ -1,7 +1,5 @@
 package com.uzabase.playtest2.core.config
 
-import com.uzabase.playtest2.core.proxy.ProxyFactory
-import com.uzabase.playtest2.core.proxy.AssertableProxyFunctions
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.forAll
 import io.kotest.data.row
@@ -24,15 +22,6 @@ data class MyMod2Configuration(
 ) : ModuleConfiguration
 
 data class Dog(val name: String, val age: Int)
-
-val FromDog = { it: Dog ->
-    ProxyFactory.make<Dog, Unit>(
-        it,
-        AssertableProxyFunctions(
-            asString = { "My dog name is ${it.name}, age is ${it.age}!!" },
-        )
-    )
-}
 
 fun myMod1(endpoint: URL): ConfigurationEntry =
     ConfigurationEntry(MyMod1ModuleKey, MyMod1Configuration(endpoint))

--- a/playtest-http/src/main/kotlin/com/uzabase/playtest2/http/FocusResponseSteps.kt
+++ b/playtest-http/src/main/kotlin/com/uzabase/playtest2/http/FocusResponseSteps.kt
@@ -3,7 +3,7 @@ package com.uzabase.playtest2.http
 import com.thoughtworks.gauge.Step
 import com.thoughtworks.gauge.datastore.ScenarioDataStore
 import com.uzabase.playtest2.core.proxy.ProxyFactory
-import com.uzabase.playtest2.http.proxy.toProxy
+import com.uzabase.playtest2.http.proxy.HttpHeadersProxy
 import java.net.http.HttpResponse
 import com.uzabase.playtest2.core.K as coreK
 import com.uzabase.playtest2.http.internal.K as intK
@@ -12,7 +12,7 @@ class FocusResponseSteps {
     @Step("レスポンスのステータスコードが")
     fun statusCode() {
         (ScenarioDataStore.get(intK.RESPONSE) as HttpResponse<*>)
-            .let { ProxyFactory.fromLongValue(it.statusCode().toLong()) }
+            .let { ProxyFactory.ofLong(it.statusCode().toLong()) }
             .let { ScenarioDataStore.put(coreK.AssertionTarget, it) }
     }
 
@@ -25,6 +25,6 @@ class FocusResponseSteps {
     @Step("レスポンスのヘッダーが", "レスポンスのヘッダーの")
     fun headers() {
         (ScenarioDataStore.get(intK.RESPONSE) as HttpResponse<*>)
-            .let { ScenarioDataStore.put(coreK.AssertionTarget, it.headers().toProxy()) }
+            .let { ScenarioDataStore.put(coreK.AssertionTarget, it.headers().let(HttpHeadersProxy::of)) }
     }
 }

--- a/playtest-http/src/main/kotlin/com/uzabase/playtest2/http/ZoomJsonSteps.kt
+++ b/playtest-http/src/main/kotlin/com/uzabase/playtest2/http/ZoomJsonSteps.kt
@@ -1,25 +1,15 @@
 package com.uzabase.playtest2.http
 
-import com.jayway.jsonpath.JsonPath
 import com.thoughtworks.gauge.Step
 import com.thoughtworks.gauge.datastore.ScenarioDataStore
 import com.uzabase.playtest2.core.K
 import com.uzabase.playtest2.core.ScenarioDataStoreExt.ensureGet
-import com.uzabase.playtest2.core.proxy.AssertableProxyFunctions
-import com.uzabase.playtest2.core.proxy.ProxyFactory
+import com.uzabase.playtest2.http.proxy.JsonPathProxy
 
 class ZoomJsonSteps {
     @Step("JSONのパス<jsonPath>に対応する値が")
     fun zoomJson(jsonPath: String): Any =
         ensureGet<String>(K.AssertionTarget)
-            .let { JsonPath.read<Any>(it, jsonPath) }
-            .let { value ->
-                ProxyFactory.make<Any, Unit>(value, AssertableProxyFunctions(
-                    asString = { value as String },
-                    asLong = { value as Long },
-                    asBoolean = { value as Boolean },
-                    asRaw = { value }
-                ))
-            }
+            .let { JsonPathProxy.of(it, jsonPath) }
             .let { ScenarioDataStore.put(K.AssertionTarget, it) }
 }

--- a/playtest-http/src/main/kotlin/com/uzabase/playtest2/http/ZoomResponseHeadersSteps.kt
+++ b/playtest-http/src/main/kotlin/com/uzabase/playtest2/http/ZoomResponseHeadersSteps.kt
@@ -12,6 +12,6 @@ class ZoomResponseHeadersSteps {
     fun zoomMap(key: String): Any =
         ScenarioDataStoreExt.ensureGet<Zoomable<String>>(K.AssertionTarget)
             .zoom(key)
-            ?.let { ScenarioDataStore.put(K.AssertionTarget, ProxyFactory.fromStringValue(it as String)) }
+            ?.let { ScenarioDataStore.put(K.AssertionTarget, ProxyFactory.ofString(it as String)) }
             ?: ScenarioDataStore.remove(K.AssertionTarget)
 }

--- a/playtest-http/src/main/kotlin/com/uzabase/playtest2/http/proxy/JsonPathProxy.kt
+++ b/playtest-http/src/main/kotlin/com/uzabase/playtest2/http/proxy/JsonPathProxy.kt
@@ -16,6 +16,6 @@ class JsonPathProxy private constructor(val json: String, val path: String) : As
 
     override fun asBoolean(): Boolean = JsonPath.read(json, path)
 
-    override fun asRaw(): String = json
+    override fun asRaw(): Any = JsonPath.read(json, path)
 
 }

--- a/playtest-http/src/main/kotlin/com/uzabase/playtest2/http/proxy/JsonPathProxy.kt
+++ b/playtest-http/src/main/kotlin/com/uzabase/playtest2/http/proxy/JsonPathProxy.kt
@@ -1,0 +1,21 @@
+package com.uzabase.playtest2.http.proxy
+
+import com.jayway.jsonpath.JsonPath
+import com.uzabase.playtest2.core.assertion.Assertable
+
+class JsonPathProxy private constructor(val json: String, val path: String) : Assertable {
+    companion object {
+        fun of(json: String, path: String): JsonPathProxy {
+            return JsonPathProxy(json, path)
+        }
+    }
+
+    override fun asLong(): Long = JsonPath.read(json, path)
+
+    override fun asString(): String = JsonPath.read(json, path)
+
+    override fun asBoolean(): Boolean = JsonPath.read(json, path)
+
+    override fun asRaw(): String = json
+
+}

--- a/playtest-http/src/main/kotlin/com/uzabase/playtest2/http/proxy/ResponseHeaders.kt
+++ b/playtest-http/src/main/kotlin/com/uzabase/playtest2/http/proxy/ResponseHeaders.kt
@@ -1,23 +1,24 @@
 package com.uzabase.playtest2.http.proxy
 
-import com.uzabase.playtest2.core.proxy.AssertableProxyFunctions
-import com.uzabase.playtest2.core.proxy.ProxyFactory
+import com.uzabase.playtest2.core.assertion.Assertable
 import com.uzabase.playtest2.core.zoom.Zoomable
 import java.net.http.HttpHeaders
 
-
-fun HttpHeaders.toProxy(): Any =
-    this.let { headers: HttpHeaders ->
-        ProxyFactory.make<HttpHeaders, String>(
-            headers,
-            AssertableProxyFunctions(
-                asString = {
-                    headers.map().entries.sortedBy { (k, _) -> k }
-                        .joinToString(System.lineSeparator()) { (k, v) -> "$k: ${v.joinToString(",")}" }
-                }
-            ),
-            zoomable = object : Zoomable<String> {
-                override fun zoom(key: String): Any? = headers.map()[key]?.joinToString(",")
-            }
-        )
+class HttpHeadersProxy private constructor(val headers: HttpHeaders) : Assertable, Zoomable<String> {
+    companion object {
+        fun of(headers: HttpHeaders): HttpHeadersProxy {
+            return HttpHeadersProxy(headers)
+        }
     }
+
+    override fun asString(): String =
+        headers.map().entries.sortedBy { (k, _) -> k }
+            .joinToString(System.lineSeparator()) { (k, v) -> "$k: ${v.joinToString(",")}" }
+
+    override fun asRaw(): HttpHeaders = headers
+
+    override fun asLong(): Long = throw UnsupportedOperationException("Cannot convert to Long")
+    override fun asBoolean(): Boolean = throw UnsupportedOperationException("Cannot convert to Boolean")
+
+    override fun zoom(key: String): Any? = headers.map()[key]?.joinToString(",")
+}

--- a/playtest-http/src/test/kotlin/com/uzabase/playtest2/http/ZoomResponseHeadersStepsTest.kt
+++ b/playtest-http/src/test/kotlin/com/uzabase/playtest2/http/ZoomResponseHeadersStepsTest.kt
@@ -3,7 +3,7 @@ package com.uzabase.playtest2.http
 import com.thoughtworks.gauge.datastore.ScenarioDataStore
 import com.uzabase.playtest2.core.K
 import com.uzabase.playtest2.core.assertion.Assertable
-import com.uzabase.playtest2.http.proxy.toProxy
+import com.uzabase.playtest2.http.proxy.HttpHeadersProxy
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -18,7 +18,7 @@ class ZoomResponseHeadersStepsTest : FunSpec({
         test("should be zoomed") {
             ScenarioDataStore.put(
                 K.AssertionTarget,
-                HttpHeaders.of(mapOf("any-header" to listOf("any")), { _, _ -> true }).toProxy()
+                HttpHeaders.of(mapOf("any-header" to listOf("any"))) { _, _ -> true }.let(HttpHeadersProxy::of)
             )
             sut.zoomMap("any-header")
             ScenarioDataStore.get(K.AssertionTarget)
@@ -29,7 +29,7 @@ class ZoomResponseHeadersStepsTest : FunSpec({
         test("should be removed if key is not found") {
             ScenarioDataStore.put(
                 K.AssertionTarget,
-                HttpHeaders.of(mapOf("any-header" to listOf("any")), { _, _ -> true }).toProxy()
+                HttpHeaders.of(mapOf("any-header" to listOf("any"))) { _, _ -> true }.let(HttpHeadersProxy::of)
             )
             sut.zoomMap("not-found")
             ScenarioDataStore.get(K.AssertionTarget).shouldBeNull()

--- a/playtest-http/src/test/kotlin/com/uzabase/playtest2/http/proxy/FromHeadersTest.kt
+++ b/playtest-http/src/test/kotlin/com/uzabase/playtest2/http/proxy/FromHeadersTest.kt
@@ -33,7 +33,7 @@ class FromHeadersTest : FunSpec({
             ),
         ) { headers, expected ->
             test("FromHeaders should convert Headers to String -- for $headers") {
-                (headers.toProxy() as Assertable).asString() shouldBe expected
+                headers.let(HttpHeadersProxy::of).asString() shouldBe expected
             }
         }
     }


### PR DESCRIPTION
仕組み的にProxyを作るための関数が必要ないと感じたので消した。
それに伴ってHttpResponseHeadersとJsonにProxyを足した